### PR TITLE
fix: improve command argument handling in ExecuteCommand function

### DIFF
--- a/internal/teleport/client.go
+++ b/internal/teleport/client.go
@@ -32,8 +32,12 @@ type ExecutionResult struct {
 
 // ExecuteCommand executes a tsh command with the given arguments
 func (c *Client) ExecuteCommand(command string, args []string) *ExecutionResult {
-	// Build the full command
-	cmdArgs := []string{command}
+	// Build the full command - split command into separate arguments
+	var cmdArgs []string
+	
+	// Split the command string into individual arguments
+	commandParts := strings.Fields(command)
+	cmdArgs = append(cmdArgs, commandParts...)
 	cmdArgs = append(cmdArgs, args...)
 
 	fullCommand := fmt.Sprintf("tsh %s", strings.Join(cmdArgs, " "))


### PR DESCRIPTION
This pull request updates the `ExecuteCommand` method in the `internal/teleport/client.go` file to improve how command arguments are handled. The key change is the introduction of logic to split the `command` string into individual arguments before appending additional arguments.

### Improvements to command argument handling:

* [`internal/teleport/client.go`](diffhunk://#diff-ad55278f3e573446be06f94b476ce3e3029ebaccb7bd25bd3b32d992c1fd8769L35-R40): Updated the `ExecuteCommand` method to split the `command` string into individual arguments using `strings.Fields`, ensuring better handling of multi-word commands. This replaces the previous approach where the `command` string was treated as a single argument.