### PR TITLE
chore: align Renovate config to Giant Swarm presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:lang-go.json5",
+  ],
+}


### PR DESCRIPTION
## Summary

- Remove minimal `renovate.json` (`config:recommended`) and replace with `renovate.json5` extending standard Giant Swarm presets
- Extends `giantswarm/renovate-presets:default.json5` (GS labels, automerge rules, `zz_generated` ignoring) and `giantswarm/renovate-presets:lang-go.json5` (Go module grouping, `gomodTidy` post-updates)
- Aligns this repo with other Team AI Go repositories

Closes #30

## Self-review

- **code-reviewer**: No critical or warning findings. Informational note about dropped `$schema` field — acceptable since the GS presets define their own scope and IDE schema validation is optional.
- **security-auditor**: No findings. Preset sources are trusted (same `giantswarm` org), no injection vectors, format change has no security impact.

## Test plan

- [ ] Verify Renovate dependency dashboard issue updates correctly on next scheduled run
- [ ] Confirm no regressions in automated dependency PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)