### PR TITLE
Add architect-orb CI pipeline, Dockerfile, and Helm chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,115 @@
+version: 2.1
+orbs:
+  architect: giantswarm/architect@6.14.1
+
+workflows:
+  build:
+    jobs:
+    - architect/go-build:
+        name: go-build-mcp-teleport
+        binary: mcp-teleport
+        filters:
+          tags:
+            only: /^v.*/
+
+    # Branch builds: amd64 only for faster PR feedback
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-registries
+        platforms: "linux/amd64"
+        requires:
+        - go-build-mcp-teleport
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag builds: push multi-arch image to gsoci (primary registry).
+    # Chart push depends on this completing successfully.
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-gsoci-release
+        registries-data: "public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true"
+        requires:
+        - go-build-mcp-teleport
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    # Tag builds: push multi-arch image to all registries (including China mirrors).
+    # Runs in parallel, does NOT block the chart push.
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-all-registries-release
+        requires:
+        - go-build-mcp-teleport
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: build-mcp-teleport-chart
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-teleport
+        push_to_appcatalog: false
+        push_to_oci_registry: false
+        persist_chart_archive: true
+        requires:
+        - go-build-mcp-teleport
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    - architect/run-tests-with-ats:
+        name: execute chart tests
+        requires:
+        - build-mcp-teleport-chart
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    # Branch: push chart after tests + amd64 image
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-mcp-teleport-to-giantswarm-app-catalog
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-teleport
+        requires:
+        - execute chart tests
+        - push-to-registries
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag: push chart after tests + gsoci image
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-mcp-teleport-to-giantswarm-app-catalog-release
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-teleport
+        requires:
+        - execute chart tests
+        - push-to-gsoci-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.circleci
+.cursor
+.goreleaser.yaml
+.dockerignore
+Dockerfile
+helm/
+README.md
+LICENSE
+Makefile
+renovate.json
+*.md
+*.swp
+*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM --platform=$BUILDPLATFORM golang:1.24.11 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-w -extldflags '-static'" \
+    -o mcp-teleport .
+
+FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm AS certs
+FROM scratch
+
+COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /etc/group /etc/group
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY --from=builder /app/mcp-teleport /mcp-teleport
+USER giantswarm
+
+ENTRYPOINT ["/mcp-teleport"]

--- a/helm/mcp-teleport/.helmignore
+++ b/helm/mcp-teleport/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/mcp-teleport/Chart.yaml
+++ b/helm/mcp-teleport/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: mcp-teleport
+description: A Helm chart for mcp-teleport - Model Context Protocol server for Teleport
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/giantswarm/mcp-teleport
+icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
+sources:
+  - https://github.com/giantswarm/mcp-teleport
+keywords:
+  - mcp
+  - teleport
+  - model-context-protocol
+maintainers:
+  - name: Giant Swarm
+    email: team-planeteers@giantswarm.io
+annotations:
+  io.giantswarm.application.team: team-planeteers
+  io.giantswarm.application.audience: customers
+  io.giantswarm.application.managed: "true"

--- a/helm/mcp-teleport/templates/NOTES.txt
+++ b/helm/mcp-teleport/templates/NOTES.txt
@@ -1,0 +1,26 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mcp-teleport.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mcp-teleport.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mcp-teleport.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mcp-teleport.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:$CONTAINER_PORT
+{{- end }}
+
+2. The MCP Teleport server is now running and ready to serve Model Context Protocol requests.
+
+3. To configure your MCP client to use this server, use the following connection details:
+   - Host: {{ include "mcp-teleport.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+   - Port: {{ .Values.service.port }}
+   - Protocol: HTTP
+
+4. For more information about using the MCP Teleport server, visit:
+   https://github.com/giantswarm/mcp-teleport

--- a/helm/mcp-teleport/templates/_helpers.tpl
+++ b/helm/mcp-teleport/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-teleport.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-teleport.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-teleport.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-teleport.labels" -}}
+helm.sh/chart: {{ include "mcp-teleport.chart" . }}
+{{ include "mcp-teleport.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-teleport.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-teleport.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mcp-teleport.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-teleport.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/mcp-teleport/templates/deployment.yaml
+++ b/helm/mcp-teleport/templates/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-teleport.fullname" . }}
+  labels:
+    {{- include "mcp-teleport.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mcp-teleport.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mcp-teleport.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-teleport.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /mcp-teleport
+          args:
+            - serve
+            - --transport={{ .Values.mcpTeleport.transport }}
+            {{- if .Values.mcpTeleport.debug }}
+            - --debug=true
+            {{- end }}
+            {{- if not .Values.mcpTeleport.nonDestructive }}
+            - --non-destructive=false
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.mcpTeleport.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/mcp-teleport/templates/service.yaml
+++ b/helm/mcp-teleport/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-teleport.fullname" . }}
+  labels:
+    {{- include "mcp-teleport.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-teleport.selectorLabels" . | nindent 4 }}

--- a/helm/mcp-teleport/templates/serviceaccount.yaml
+++ b/helm/mcp-teleport/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-teleport.serviceAccountName" . }}
+  labels:
+    {{- include "mcp-teleport.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/mcp-teleport/values.schema.json
+++ b/helm/mcp-teleport/values.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "Never", "IfNotPresent"]
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": ["registry", "repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer"
+        }
+      }
+    },
+    "mcpTeleport": {
+      "type": "object",
+      "properties": {
+        "transport": {
+          "type": "string",
+          "enum": ["stdio", "sse", "streamable-http"]
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "nonDestructive": {
+          "type": "boolean"
+        },
+        "env": {
+          "type": "array"
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "volumes": {
+      "type": "array"
+    },
+    "volumeMounts": {
+      "type": "array"
+    }
+  }
+}

--- a/helm/mcp-teleport/values.yaml
+++ b/helm/mcp-teleport/values.yaml
@@ -1,0 +1,72 @@
+# Default values for mcp-teleport.
+
+replicaCount: 1
+
+image:
+  registry: gsoci.azurecr.io
+  repository: giantswarm/mcp-teleport
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  capabilities:
+    drop:
+    - ALL
+
+service:
+  type: ClusterIP
+  port: 8080
+
+mcpTeleport:
+  # Transport type: stdio, sse, or streamable-http
+  transport: streamable-http
+  # Enable debug logging
+  debug: false
+  # Enable non-destructive mode (default: true)
+  nonDestructive: true
+  # Additional environment variables
+  env: []
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+volumes: []
+volumeMounts: []


### PR DESCRIPTION
## Summary

- Add multi-stage **Dockerfile** producing a minimal scratch-based container image with the statically-linked Go binary, following the mcp-kubernetes pattern
- Add **`.circleci/config.yml`** with `giantswarm/architect@6.14.1` orb: `go-build`, `push-to-registries-multiarch` (amd64 for branches, multi-arch for tags), `push-to-app-catalog`, and `run-tests-with-ats` jobs
- Add **Helm chart** in `helm/mcp-teleport/` with deployment, service, serviceaccount templates, hardened security contexts (non-root, read-only rootfs, all capabilities dropped, seccomp RuntimeDefault), and values schema validation
- Add `.dockerignore` to exclude non-build files from the Docker build context
- Existing GoReleaser workflow is preserved for standalone binary releases

## Security review notes

- Container runs as non-root user (UID 1000) in a scratch-based image
- All capabilities dropped, privilege escalation blocked, read-only root filesystem
- ServiceAccount token automount disabled at pod level
- `automountServiceAccountToken: false` set on both ServiceAccount and pod spec
- Seccomp profile set to RuntimeDefault

## Test plan

- [ ] Verify `docker build` succeeds and produces a working container image
- [ ] Verify CircleCI pipeline triggers correctly on branch push
- [ ] Verify Helm chart linting passes (`helm lint helm/mcp-teleport/`)
- [ ] Verify chart template rendering (`helm template test helm/mcp-teleport/`)
- [ ] Verify tag builds produce multi-arch images pushed to gsoci
- [ ] Verify chart tests pass via `architect/run-tests-with-ats`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)